### PR TITLE
Install batman-package from pip along with batman

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,8 +4,8 @@ MAINTAINER LSIT Systems <lsitops@lsit.ucsb.edu>
 
 USER root
 
-RUN conda install -y astropy photutils batman-package
+RUN conda install -y astropy photutils
 
-RUN pip install --upgrade git+https://github.com/lkreidberg/batman.git
+RUN pip install --upgrade batman-package git+https://github.com/lkreidberg/batman.git 
 
 USER $NB_USER


### PR DESCRIPTION
Fix for the broken batman-package dep in conda-forge:

```
LibMambaUnsatisfiableError: Encountered problems while solving:
  - unsupported request
  - package batman-package-2.4.9-py310h61a050e_2 requires python >=3.10,<3.11.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ batman-package =* * is installable with the potential options
│  ├─ batman-package [2.4.8|2.4.9|2.5.2] would require
│  │  └─ python >=3.10,<3.11.0a0 *, which can be installed;
│  ├─ batman-package [2.4.9|2.5.2] would require
│  │  └─ python >=3.11,<3.12.0a0 *, which can be installed;
│  ├─ batman-package [2.4.9|2.5.2] would require
│  │  └─ python >=3.12,<3.13.0a0 *, which can be installed;
│  ├─ batman-package [2.4.6|2.4.7|2.4.8|2.4.9] would require
│  │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│  ├─ batman-package [2.4.7|2.4.8|2.4.9|2.5.2] would require
│  │  └─ python >=3.9,<3.10.0a0 *, which can be installed;
│  ├─ batman-package [2.4.6|2.4.7|2.4.8] would require
│  │  └─ python >=3.6,<3.7.0a0 *, which can be installed;
│  └─ batman-package [2.4.6|2.4.7|2.4.8|2.4.9] would require
│     └─ python >=3.7,<3.8.0a0 *, which can be installed;
├─ blas*.* =* * does not exist (perhaps a typo or a missing channel);
└─ pin on python =3.13 * is not installable because it requires
   └─ python =3.13 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.13
 ```